### PR TITLE
Revert "Remove deprecated erg formula"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,3 @@ that hasn't been packaged elsewhere.
 
     brew tap square/self
     brew install <formulaname>
-
-Note that the `erg` formula has moved to the `square/self` tap.

--- a/erg.rb
+++ b/erg.rb
@@ -1,0 +1,18 @@
+require "formula"
+
+class Erg < Formula
+  homepage "https://github.com/square/erg"
+  url "https://github.com/square/erg/archive/v1.2.1.tar.gz"
+  head "https://github.com/square/erg.git"
+  sha256 "2552a849a785e4f3c2252c4862d938794e791eea84d23ec7dfc89fce621244e6"
+
+  depends_on 'go' => :build
+
+  def install
+    ENV['GOPATH'] = buildpath
+    system 'go', 'get', 'github.com/square/erg'
+    system 'go', 'get', 'github.com/droundy/goopt'
+    system 'go', 'build', 'main/erg.go'
+    bin.install 'erg'
+  end
+end


### PR DESCRIPTION
This reverts commit 4e085a87a7b34a8b3b2d0e759e11174289f60ad5.

The readme change seems to indicate this was a mistake.